### PR TITLE
Fix Stored XSS in Guestbook via javascript: URI

### DIFF
--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -160,6 +160,15 @@ const GOOGLE_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbxxRtJRGDs9Mb
     return div.innerHTML;
   }
 
+  function isValidUrl(string) {
+    try {
+      const url = new URL(string);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch (_) {
+      return false;
+    }
+  }
+
   // Generate consistent color from name
   function getAvatarColor(name) {
     const colors = [
@@ -188,7 +197,7 @@ const GOOGLE_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbxxRtJRGDs9Mb
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-baseline gap-2 mb-1">
-              ${entry.website
+              ${entry.website && isValidUrl(entry.website)
                 ? `<a href="${escapeHtml(entry.website)}" target="_blank" rel="noopener noreferrer" class="font-medium text-slate-900 dark:text-slate-100 hover:text-slate-600 dark:hover:text-slate-300 transition-colors">${escapeHtml(entry.name)}</a>`
                 : `<span class="font-medium text-slate-900 dark:text-slate-100">${escapeHtml(entry.name)}</span>`
               }


### PR DESCRIPTION
This PR fixes a Stored Cross-Site Scripting (XSS) vulnerability in the Guestbook page.

**Vulnerability:**
The `website` field in the guestbook entry was rendered as an `<a href="...">` link without validating the URI scheme. This allowed an attacker to submit a `javascript:` URI (e.g., `javascript:alert('XSS')`), which would execute arbitrary JavaScript in the context of the victim's browser when clicked.

**Fix:**
- Introduced a `isValidUrl(string)` function in `src/pages/guestbook.astro`.
- The function uses the `URL` API to parse the string and checks if the protocol is either `http:` or `https:`.
- Updated the `renderMessage` function to use `isValidUrl` to check `entry.website`.
- If the website URL is invalid (or uses a disallowed scheme), the entry is rendered as plain text (using a `<span>` tag) instead of a link.

**Verification:**
- Verified using a reproduction script that `javascript:` URIs are no longer rendered as links.
- Verified that valid `https://` URLs are still rendered correctly.
- Verified that the UI falls back gracefully for invalid URLs.

---
*PR created automatically by Jules for task [7893166604232443426](https://jules.google.com/task/7893166604232443426) started by @1Mangesh1*