### PR TITLE
feat: add custom native theme for Giscus comments

### DIFF
--- a/public/styles/giscus-dark.css
+++ b/public/styles/giscus-dark.css
@@ -1,0 +1,80 @@
+/*! Custom Giscus Theme - Dark Mode */
+main {
+  /* Variables matching Tailwind's dark mode palette */
+  --color-prettylights-syntax-comment: #8b949e;
+  --color-prettylights-syntax-entity: #79c0ff;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-variable: #ffa657;
+  --color-prettylights-syntax-keyword: #ff7b72;
+
+  --color-canvas-default: #111827; /* bg-gray-900 */
+  --color-canvas-overlay: #1f2937; /* bg-gray-800 */
+  --color-canvas-inset: #1f2937;
+  --color-canvas-subtle: #1f2937;
+
+  --color-border-default: #374151; /* border-gray-700 */
+  --color-border-muted: #374151;
+
+  --color-neutral-muted: #6e7681;
+
+  --color-accent-fg: #60a5fa; /* text-blue-400 */
+  --color-accent-emphasis: #2563eb; /* bg-blue-600 */
+  --color-accent-muted: #388bfd66;
+  --color-accent-subtle: #388bfd26;
+
+  --color-fg-default: #f3f4f6; /* text-gray-100 */
+  --color-fg-muted: #d1d5db; /* text-gray-300 */
+  --color-fg-subtle: #9ca3af; /* text-gray-400 */
+
+  --color-btn-text: #f3f4f6; /* text-gray-100 */
+  --color-btn-bg: #1f2937; /* bg-gray-800 */
+  --color-btn-border: #4b5563; /* border-gray-600 */
+  --color-btn-shadow: 0 0 transparent;
+  --color-btn-inset-shadow: 0 0 transparent;
+  --color-btn-hover-bg: #374151; /* hover:bg-gray-700 */
+  --color-btn-hover-border: #6b7280; /* border-gray-500 */
+  --color-btn-active-bg: #4b5563;
+  --color-btn-active-border: #6b7280;
+
+  --color-btn-primary-text: #ffffff;
+  --color-btn-primary-bg: #2563eb; /* bg-blue-600 */
+  --color-btn-primary-border: rgba(240,246,252,0.1);
+  --color-btn-primary-shadow: 0 0 transparent;
+  --color-btn-primary-inset-shadow: 0 0 transparent;
+  --color-btn-primary-hover-bg: #1d4ed8; /* hover:bg-blue-700 */
+  --color-btn-primary-hover-border: rgba(240,246,252,0.1);
+
+  --color-scale-gray-1: #21262d;
+  --color-scale-blue-1: #1f6feb;
+}
+
+main .pagination-loader-container {
+  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+}
+
+/* Custom fonts and overrides */
+.gsc-main {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+.gsc-comment-box-textarea {
+  background-color: #1f2937; /* bg-gray-800 */
+  border-color: #4b5563; /* border-gray-600 */
+  color: #f3f4f6;
+  border-radius: 0.5rem; /* rounded-lg */
+}
+
+.gsc-comment-box-textarea:focus {
+  border-color: #60a5fa; /* focus:ring-blue-400 */
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.5); /* focus:ring-2 */
+}
+
+/* Adjust links */
+a {
+  text-decoration: none;
+  font-weight: 500;
+}
+a:hover {
+  text-decoration: underline;
+}

--- a/public/styles/giscus-light.css
+++ b/public/styles/giscus-light.css
@@ -1,0 +1,85 @@
+/*! Custom Giscus Theme - Light Mode */
+main {
+  /* Variables matching Tailwind's light mode palette */
+  --color-prettylights-syntax-comment: #6e7781;
+  --color-prettylights-syntax-entity: #0550ae;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-variable: #953800;
+  --color-prettylights-syntax-keyword: #cf222e;
+
+  --color-canvas-default: #ffffff; /* bg-white */
+  --color-canvas-overlay: #ffffff;
+  --color-canvas-inset: #f6f8fa;
+  --color-canvas-subtle: #f6f8fa;
+
+  --color-border-default: #e5e7eb; /* border-gray-200 */
+  --color-border-muted: #e5e7eb;
+
+  --color-neutral-muted: #afb8c1;
+
+  --color-accent-fg: #2563eb; /* text-blue-600 */
+  --color-accent-emphasis: #2563eb; /* bg-blue-600 */
+  --color-accent-muted: #ddf4ff;
+  --color-accent-subtle: #ddf4ff;
+
+  --color-fg-default: #111827; /* text-gray-900 */
+  --color-fg-muted: #4b5563; /* text-gray-600 */
+  --color-fg-subtle: #6b7280; /* text-gray-500 */
+
+  --color-btn-text: #374151; /* text-gray-700 */
+  --color-btn-bg: #f3f4f6; /* bg-gray-100 */
+  --color-btn-border: #d1d5db; /* border-gray-300 */
+  --color-btn-shadow: 0 1px 0 rgba(27,31,35,0.04);
+  --color-btn-inset-shadow: inset 0 1px 0 rgba(255,255,255,0.25);
+  --color-btn-hover-bg: #e5e7eb; /* hover:bg-gray-200 */
+  --color-btn-hover-border: #d1d5db;
+  --color-btn-active-bg: #ebecf0;
+  --color-btn-active-border: #d1d5db;
+
+  --color-btn-primary-text: #ffffff;
+  --color-btn-primary-bg: #2563eb; /* bg-blue-600 */
+  --color-btn-primary-border: rgba(27,31,35,0.15);
+  --color-btn-primary-shadow: 0 1px 0 rgba(27,31,35,0.1);
+  --color-btn-primary-inset-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+  --color-btn-primary-hover-bg: #1d4ed8; /* hover:bg-blue-700 */
+  --color-btn-primary-hover-border: rgba(27,31,35,0.15);
+
+  --color-scale-gray-1: #eaeef2;
+  --color-scale-blue-1: #b6e3ff;
+}
+
+main .pagination-loader-container {
+  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+}
+
+/* Custom fonts and overrides */
+.gsc-main {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+.gsc-header {
+  padding-bottom: 1rem;
+}
+
+/* Style the comment box to match site inputs */
+.gsc-comment-box-textarea {
+  background-color: #ffffff;
+  border-color: #d1d5db; /* border-gray-300 */
+  color: #111827;
+  border-radius: 0.5rem; /* rounded-lg */
+}
+
+.gsc-comment-box-textarea:focus {
+  border-color: #2563eb; /* focus:ring-blue-500 */
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.5); /* focus:ring-2 */
+}
+
+/* Adjust links */
+a {
+  text-decoration: none;
+  font-weight: 500;
+}
+a:hover {
+  text-decoration: underline;
+}

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -1,18 +1,78 @@
 <div class="giscus mt-16"></div>
 
-<script src="https://giscus.app/client.js"
-        data-repo="1mangesh1/1mangesh1.github.io"
-        data-repo-id="R_kgDONJZqoA"
-        data-category="Comments"
-        data-category-id="DIC_kwDONJZqoM4C2FCx"
-        data-mapping="pathname"
-        data-strict="0"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-input-position="bottom"
-        data-theme="preferred_color_scheme"
-        data-lang="en"
-        data-loading="lazy"
-        crossorigin="anonymous"
-        async>
+<script>
+  function loadGiscus() {
+    const container = document.querySelector('.giscus');
+    // Prevent double loading if script runs twice (e.g. view transitions)
+    if (!container || container.querySelector('iframe')) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.setAttribute('data-repo', '1mangesh1/1mangesh1.github.io');
+    script.setAttribute('data-repo-id', 'R_kgDONJZqoA');
+    script.setAttribute('data-category', 'Comments');
+    script.setAttribute('data-category-id', 'DIC_kwDONJZqoM4C2FCx');
+    script.setAttribute('data-mapping', 'pathname');
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'bottom');
+    script.setAttribute('data-lang', 'en');
+    script.setAttribute('data-loading', 'lazy');
+    script.crossOrigin = 'anonymous';
+    script.async = true;
+
+    // Determine initial theme
+    const isDark = document.documentElement.classList.contains('dark') ||
+                   (localStorage.getItem('theme') === 'dark') ||
+                   (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+    // Construct absolute URL for the theme file
+    const origin = window.location.origin;
+    const themeUrl = isDark
+      ? `${origin}/styles/giscus-dark.css`
+      : `${origin}/styles/giscus-light.css`;
+
+    script.setAttribute('data-theme', themeUrl);
+
+    container.appendChild(script);
+
+    // Theme toggling logic
+    function setGiscusTheme(theme) {
+      const iframe = document.querySelector('iframe.giscus-frame');
+      if (!iframe) return;
+
+      const newThemeUrl = theme === 'dark'
+        ? `${window.location.origin}/styles/giscus-dark.css`
+        : `${window.location.origin}/styles/giscus-light.css`;
+
+      // @ts-ignore
+      iframe.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme: newThemeUrl } } },
+        'https://giscus.app'
+      );
+    }
+
+    // Observer for theme changes
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          const isDarkNow = document.documentElement.classList.contains('dark');
+          setGiscusTheme(isDarkNow ? 'dark' : 'light');
+        }
+      });
+    });
+
+    observer.observe(document.documentElement, { attributes: true });
+  }
+
+  // Load on idle or immediately
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadGiscus);
+  } else {
+    loadGiscus();
+  }
+
+  // Re-run on Astro page transitions if they are added later
+  document.addEventListener('astro:page-load', loadGiscus);
 </script>


### PR DESCRIPTION
This PR introduces a custom styling solution for Giscus comments to make them look native to the site's design.

Changes:
1.  **Custom Themes**: Created `public/styles/giscus-light.css` and `public/styles/giscus-dark.css`. These files define CSS variables that Giscus uses, mapped to the site's existing Tailwind colors (e.g., `gray-900` for dark background, `blue-600` for primary actions).
2.  **Dynamic Component**: Refactored `src/components/Giscus.astro` to handle theme initialization and switching. It now detects the user's preferred color scheme or manually toggled theme and loads the corresponding CSS file.
3.  **Seamless Toggling**: Added a `MutationObserver` to the component script. When the user toggles the site's theme (adding/removing `class="dark"` on `html`), the script sends a message to the Giscus iframe to swap the theme instantly without reloading the comments.

Verification:
- Validated CSS application using a mock HTML page and Playwright screenshots for both light and dark modes.
- Verified that the component logic correctly constructs absolute URLs for the theme files, which is required for Giscus to load external stylesheets.


---
*PR created automatically by Jules for task [910545919129985402](https://jules.google.com/task/910545919129985402) started by @1Mangesh1*