### PR TITLE
🧹 Improve type safety in games.astro

### DIFF
--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -749,20 +749,27 @@ import Layout from "../layouts/Layout.astro";
   </div>
 
   <script>
+    // Type definitions
+    interface GameInstance {
+      destroy?: () => void;
+    }
+
+    type GameConstructor = new () => GameInstance;
+
     // Game management functions
-    let currentGame: any = null;
+    let currentGame: GameInstance | null = null;
 
     // Extend window interface for global functions
     interface GameWindow extends Window {
-      PixelStudio?: any;
-      ChaosMachine?: any;
-      BugBlaster?: any;
-      CodeSnake?: any;
-      DevMemory?: any;
-      CodeTyper?: any;
-      CodeHangman?: any;
-      TypingTest?: any;
-      DevBingo?: any;
+      PixelStudio?: GameConstructor;
+      ChaosMachine?: GameConstructor;
+      BugBlaster?: GameConstructor;
+      CodeSnake?: GameConstructor;
+      DevMemory?: GameConstructor;
+      CodeTyper?: GameConstructor;
+      CodeHangman?: GameConstructor;
+      TypingTest?: GameConstructor;
+      DevBingo?: GameConstructor;
       showGame?: (gameType: string) => void;
       hideGame?: () => void;
     }
@@ -994,9 +1001,10 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/useless-machine.js", () => {
             if (gameWindow.ChaosMachine) {
+              const ChaosMachineClass = gameWindow.ChaosMachine;
               // Add a slight delay to ensure DOM is fully ready
               setTimeout(() => {
-                currentGame = new gameWindow.ChaosMachine();
+                currentGame = new ChaosMachineClass();
               }, 100);
             }
           });
@@ -1070,9 +1078,10 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/wack-a-bug.js", () => {
             if (gameWindow.BugBlaster) {
+              const BugBlasterClass = gameWindow.BugBlaster;
               // Add a slight delay to ensure DOM is fully ready
               setTimeout(() => {
-                currentGame = new gameWindow.BugBlaster();
+                currentGame = new BugBlasterClass();
               }, 100);
             }
           });
@@ -1150,8 +1159,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/code-snake.js", () => {
             if (gameWindow.CodeSnake) {
+              const CodeSnakeClass = gameWindow.CodeSnake;
               setTimeout(() => {
-                currentGame = new gameWindow.CodeSnake();
+                currentGame = new CodeSnakeClass();
               }, 100);
             }
           });
@@ -1257,8 +1267,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/dev-memory.js", () => {
             if (gameWindow.DevMemory) {
+              const DevMemoryClass = gameWindow.DevMemory;
               setTimeout(() => {
-                currentGame = new gameWindow.DevMemory();
+                currentGame = new DevMemoryClass();
               }, 100);
             }
           });
@@ -1363,8 +1374,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/code-typer.js", () => {
             if (gameWindow.CodeTyper) {
+              const CodeTyperClass = gameWindow.CodeTyper;
               setTimeout(() => {
-                currentGame = new gameWindow.CodeTyper();
+                currentGame = new CodeTyperClass();
               }, 100);
             }
           });
@@ -1446,8 +1458,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/hangman.js", () => {
             if (gameWindow.CodeHangman) {
+              const CodeHangmanClass = gameWindow.CodeHangman;
               setTimeout(() => {
-                currentGame = new gameWindow.CodeHangman();
+                currentGame = new CodeHangmanClass();
               }, 100);
             }
           });
@@ -1509,8 +1522,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/typing-test.js", () => {
             if (gameWindow.TypingTest) {
+              const TypingTestClass = gameWindow.TypingTest;
               setTimeout(() => {
-                currentGame = new gameWindow.TypingTest();
+                currentGame = new TypingTestClass();
               }, 100);
             }
           });
@@ -1573,8 +1587,9 @@ import Layout from "../layouts/Layout.astro";
         } else {
           loadScript("/game-scripts/dev-bingo.js", () => {
             if (gameWindow.DevBingo) {
+              const DevBingoClass = gameWindow.DevBingo;
               setTimeout(() => {
-                currentGame = new gameWindow.DevBingo();
+                currentGame = new DevBingoClass();
               }, 100);
             }
           });


### PR DESCRIPTION
Replaced `any` types in `src/pages/games.astro` with proper interfaces (`GameInstance`, `GameConstructor`) to improve type safety and maintainability. Also fixed type narrowing issues where `window` properties accessed inside `setTimeout` callbacks were not guaranteed to be defined by TypeScript flow analysis.

---
*PR created automatically by Jules for task [98943626945601167](https://jules.google.com/task/98943626945601167) started by @1Mangesh1*