### PR TITLE
🧹 Replace unsafe eval() with new Function() in Code Golf

### DIFF
--- a/src/pages/codegolf.astro
+++ b/src/pages/codegolf.astro
@@ -228,7 +228,9 @@ import Layout from '../layouts/Layout.astro';
   document.getElementById('run-btn')!.addEventListener('click', () => {
     try {
       const code = codeInput.value;
-      const result = eval(`(function() { ${code}; return typeof solve !== 'undefined' ? solve : null; })()`);
+      // Using new Function() instead of eval() for safer execution.
+      // This prevents access to local scope variables, though global scope access remains.
+      const result = new Function(`"use strict"; ${code}; return typeof solve !== 'undefined' ? solve : null;`)();
 
       if (typeof result === 'function') {
         // Test with sample input
@@ -249,7 +251,8 @@ import Layout from '../layouts/Layout.astro';
   document.getElementById('test-btn')!.addEventListener('click', () => {
     try {
       const code = codeInput.value;
-      const fn = eval(`(function() { ${code}; return solve; })()`);
+      // Using new Function() instead of eval() for safer execution.
+      const fn = new Function(`"use strict"; ${code}; return solve;`)();
 
       const challenge = challenges[currentChallenge];
       const passed = challenge.test(fn);


### PR DESCRIPTION
**What:** Replaced `eval()` with `new Function()` in `src/pages/codegolf.astro`.
**Why:** Improves code health and security by preventing user code from accessing the local scope (variables like `codeInput`, `challenges`, etc.). `new Function` always executes in the global scope.
**Verification:**
- Verified with a reproduction script (`test_eval_replacement.js`) that `new Function` behaves correctly for defining functions while blocking access to local variables.
- Verified frontend functionality (Run Code, Test Solution) using a Playwright script (`verify_codegolf.py`) and visual inspection of screenshot.
- Ran `npm run build` (including `astro check`) successfully.
**Result:** The code is cleaner and safer without changing user-facing functionality.

---
*PR created automatically by Jules for task [8543898360440703598](https://jules.google.com/task/8543898360440703598) started by @1Mangesh1*