### PR TITLE
Add blog post: Why Your Database Schema Matters More Than Your Framework

### DIFF
--- a/src/content/blog/database-schema-matters-more-than-framework.md
+++ b/src/content/blog/database-schema-matters-more-than-framework.md
@@ -1,0 +1,92 @@
+---
+title: "Why Your Database Schema Matters More Than Your Framework"
+description: "Frameworks come and go, but data is forever. Learn why investing in a solid database schema pays higher dividends than chasing the latest JS trend."
+pubDate: 2025-02-26T00:00:00Z
+tags: ["Database", "Architecture", "SQL", "Opinion"]
+draft: false
+---
+
+Here's the reality: your Next.js app will be rewritten in 18 months. Your database will likely survive for 10 years.
+
+We spend weeks debating React vs Svelte, Server Components vs HTMX, but treat our database like a glorified JSON store. This is a mistake.
+
+## The "Schemaless" Trap
+
+ORMs (Object-Relational Mappers) sell us a lie: that we don't need to know SQL. That we can treat rows like objects and forget about normalization.
+
+So we write code like this:
+
+```typescript
+// bad-idea.ts
+const createUser = async (data) => {
+  // Application-level validation? Good luck maintaining this everywhere.
+  if (!data.email.includes('@')) throw new Error('Invalid email');
+
+  await db.users.create({
+    data: JSON.stringify(data) // "Flexible" storage
+  });
+}
+```
+
+But what happens when another service writes to the DB? Or a migration script? Or a manual fix by a sleep-deprived dev at 3 AM?
+
+Without constraints, your data becomes garbage. You end up writing "application-level" integrity checks that are slow, buggy, and impossible to keep consistent across multiple codebases.
+
+## Let the Database Do the Work
+
+Postgres is smarter than your Node.js server. It has decades of optimization for data integrity. Use it.
+
+Don't just rely on Zod or Joi schemas in your API layer. Those are for user input validation, not data integrity.
+
+### 1. Strict Types
+Don't use `text` for everything. Use `uuid`, `timestamptz`, `inet` for IP addresses. If a column is a boolean, make it a `BOOLEAN`, not a `TINYINT(1)`.
+
+### 2. Constraints Are Not Optional
+`NOT NULL` should be your default. `UNIQUE` indexes prevent duplicates faster than any `SELECT` check in your code. `CHECK` constraints ensure your integers are positive or your strings match a regex.
+
+### 3. Foreign Keys
+Enforce relationships at the data level. If you delete a user, their posts should either be deleted (`ON DELETE CASCADE`) or the operation should fail. Don't leave orphaned records floating in the void.
+
+## Code Comparison
+
+Here is a typical "move fast and break things" schema. It looks easy to start with, but it's a nightmare to query later.
+
+```sql
+-- The "I'll fix it later" Schema
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  data JSONB -- "Flexible" (Lazy)
+);
+```
+
+Here is a schema that respects your future self. It documents your data model better than any Wiki page.
+
+```sql
+-- The "Sleep well at night" Schema
+CREATE TABLE tiers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  price_cents INTEGER NOT NULL CHECK (price_cents >= 0)
+);
+
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE CHECK (email ~* '^.+@.+\..+$'),
+  tier_id INTEGER NOT NULL REFERENCES tiers(id),
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index strictly for query patterns you actually have
+CREATE INDEX idx_users_tier_active ON users(tier_id) WHERE is_active = true;
+```
+
+## Data Outlives Code
+
+Frameworks are fashion. Data is infrastructure.
+
+Ten years from now, nobody will care if you used Redux or Zustand. But if your `users` table is full of duplicate emails and broken foreign keys, your company is in trouble.
+
+Stop chasing the new shiny toy. Learn SQL. Design your schema before you write a single line of TypeScript.
+
+Your future self (and the poor soul who inherits your codebase) will thank you.


### PR DESCRIPTION
Added a new blog post 'database-schema-matters-more-than-framework.md' following the 'Mangesh' persona and technical guidelines. The post argues for investing in solid database schema design over chasing framework trends. It includes code examples (SQL vs JS) and adheres to strict frontmatter and style constraints.

---
*PR created automatically by Jules for task [1115449403727389066](https://jules.google.com/task/1115449403727389066) started by @1Mangesh1*