### PR TITLE
feat(blog): add post advocating PostgreSQL JSONB over MongoDB

### DIFF
--- a/src/content/blog/stop-defaulting-to-mongodb-postgres-jsonb.md
+++ b/src/content/blog/stop-defaulting-to-mongodb-postgres-jsonb.md
@@ -1,0 +1,124 @@
+---
+title: "Stop Defaulting to MongoDB: Why Postgres JSONB Wins"
+description: "For years we defaulted to NoSQL for unstructured data. Here is why PostgreSQL 16 with JSONB is the only database you actually need for your next SaaS."
+pubDate: 2026-03-04T16:05:57Z
+tags: ["PostgreSQL", "MongoDB", "Database", "SaaS", "Architecture"]
+draft: false
+---
+
+Here's the reality: we've been lied to about NoSQL. For the past decade, the standard advice for building a new SaaS was to start with MongoDB "for flexibility." The idea was simple—your data model is going to change rapidly, so you need a schemaless database.
+
+It sounds great in a slide deck. In production, it's a completely different story.
+
+I've watched teams build early-stage products on MongoDB, only to hit a wall 18 months later. Suddenly, they need complex joins, transactional integrity, and reporting. What happens next? They build an ad-hoc, brittle application-layer ORM to enforce the very schema they were trying to avoid.
+
+Stop doing this.
+
+The flexibility you think you need doesn't require a NoSQL database. It requires PostgreSQL. Specifically, it requires PostgreSQL 16 and its incredible `JSONB` support.
+
+Here is what actual, necessary flexibility looks like:
+- **Dynamic user preferences:** Settings that change weekly without requiring schema migrations.
+- **Third-party webhooks:** Ingesting variable payloads from Stripe or GitHub.
+- **Form builders:** Storing arbitrary user-defined inputs gracefully.
+
+### The Schema Flexibility Myth
+
+The core problem with MongoDB isn't the technology itself—it's how it's applied.
+
+When you start a project, you rarely have zero structure. You have users. Users have emails, passwords, and creation dates. This is highly relational data. But then you have user *preferences*, or dynamic form submissions, or third-party API payloads. That data is messy.
+
+MongoDB forces you to treat *all* your data as messy. PostgreSQL lets you be precise where you need precision, and flexible where you need flexibility.
+
+If you need to store dynamic user configurations, you don't need a document database. You just need a `JSONB` column.
+
+### Enter PostgreSQL JSONB
+
+Postgres isn't just "good enough" at JSON. It's exceptional. The `JSONB` data type stores JSON in a decomposed binary format. This means it's not just a dumb string column. Postgres understands the internal structure of the JSON object.
+
+You can query inside the JSON object, index specific keys, and even perform complex updates without pulling the entire document into application memory.
+
+Let's look at how you actually use this in a multi-tenant SaaS.
+
+### Building Flexible Schemas with Postgres
+
+Imagine you're building a CRM. You have a `customers` table. Every customer has a name and an email. But every tenant (your users) wants to store custom fields for their customers.
+
+Instead of an Entity-Attribute-Value (EAV) anti-pattern, or spinning up MongoDB, you do this:
+
+```sql
+CREATE TABLE customers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    custom_fields JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index the tenant_id for fast lookups
+CREATE INDEX idx_customers_tenant ON customers(tenant_id);
+
+-- Create a GIN index on the JSONB column for hyper-fast querying
+CREATE INDEX idx_customers_custom_fields ON customers USING GIN (custom_fields);
+```
+
+Now, tenant A wants to store a customer's `lead_score`, and tenant B wants to store `preferred_contact_method`.
+
+```sql
+-- Tenant A inserts a customer
+INSERT INTO customers (tenant_id, email, name, custom_fields)
+VALUES (
+    'a1b2c3d4',
+    'alice@example.com',
+    'Alice Smith',
+    '{"lead_score": 85, "source": "webinar"}'
+);
+
+-- Tenant B inserts a customer
+INSERT INTO customers (tenant_id, email, name, custom_fields)
+VALUES (
+    'e5f6g7h8',
+    'bob@example.com',
+    'Bob Jones',
+    '{"preferred_contact_method": "SMS", "vip_status": true}'
+);
+```
+
+### Querying Inside JSONB
+
+The real power unlocks when you need to query this data. Postgres provides robust operators to dive into the JSON structure.
+
+Want to find all customers for Tenant A with a lead score greater than 80?
+
+```sql
+SELECT name, email, custom_fields->>'lead_score' as score
+FROM customers
+WHERE tenant_id = 'a1b2c3d4'
+  AND (custom_fields->>'lead_score')::int > 80;
+```
+
+Notice the operator `->>`. This extracts the JSON object field as text. We then cast it to an integer `::int` for the comparison. Because of the GIN index we created earlier, this query is blisteringly fast, even with millions of rows.
+
+You get the flexibility of a NoSQL document store, seamlessly combined with the ACID compliance, foreign keys, and reporting capabilities of the world's most advanced relational database.
+
+### But What About Performance?
+
+I know what you're thinking. "Isn't MongoDB faster for document retrieval?"
+
+In most practical SaaS workloads, no.
+
+When benchmarking API endpoints, the bottleneck is rarely the database's ability to read a single document. The bottleneck is network latency, application logic, and complex data aggregation.
+
+Postgres gives you the ability to use `JOIN`s. In MongoDB, if you need to fetch a user and their recent orders, you're either doing multiple round trips to the database or you're fighting with the complex aggregation pipeline. In Postgres, it's a single, highly optimized SQL query.
+
+Postgres 16 also introduced massive improvements to parallel query execution and query planning. If you configure your connection pooler (like PgBouncer) correctly, Postgres will handle thousands of concurrent requests without breaking a sweat.
+
+### The Verdict
+
+I prefer PostgreSQL over MongoDB for almost every new project because it eliminates the "database migration" anxiety.
+
+When your data is simple and flexible, `JSONB` handles it beautifully. When your application matures and those dynamic fields become critical business logic, you can easily promote them to first-class relational columns.
+
+You don't need a polyglot persistence architecture on day one. You don't need to manage two different database clusters.
+
+Start with Postgres. Use `JSONB` for the messy stuff. Keep your architecture boring, and spend your time building features your users actually care about.


### PR DESCRIPTION
This PR adds a new blog post titled "Stop Defaulting to MongoDB: Why Postgres JSONB Wins" to the Astro blog. It strictly adheres to the "Mangesh" persona and the Astro+MDX technical constraints. It includes:
- Correct frontmatter schema and `[slug].md` file naming convention.
- A technical, direct, opinionated, and experienced tone.
- Concrete SQL code examples.
- No AI-isms (e.g. "In conclusion", "Moreover").
- Bulleted lists as requested.

---
*PR created automatically by Jules for task [6371473156374800383](https://jules.google.com/task/6371473156374800383) started by @1Mangesh1*