### PR TITLE
Add new blog post about Docker over-engineering

### DIFF
--- a/src/content/blog/stop-over-engineering-docker-images.md
+++ b/src/content/blog/stop-over-engineering-docker-images.md
@@ -1,0 +1,122 @@
+---
+title: "Why You Should Stop Over-Engineering Your Docker Images"
+description: "Slow builds, huge images, and broken caching. Here is how to write simple, fast Dockerfiles that actually work in production."
+pubDate: 2025-03-09T00:00:00Z
+tags: ["Docker", "DevOps", "Performance", "Web Development"]
+draft: false
+---
+
+Here's the reality: complex Dockerfiles are a liability, not a badge of honor.
+
+For the past 18 months, I've watched teams build absurdly complicated container images using the old way:
+- Chaining twenty `RUN` commands together with backslashes
+- Installing unnecessary build tools in the final stage
+- Destroying cache layers by putting `COPY . .` at the very top
+- Waiting 15 minutes for a CI build that should take 30 seconds
+
+Then they realize their image is 1.5GB for a simple Node.js app.
+
+Everything changes when you focus on the fundamentals.
+
+Instead of writing custom shell scripts inside your Dockerfile → you leverage multi-stage builds.
+Instead of hoping the cache hits → you order your layers strategically.
+Instead of managing chaos → you build systems that scale.
+
+This guide shows you *exactly* how to fix your Docker setup. Not theoretical. Not complex. Real fixes you can deploy today.
+
+---
+
+## The Problem With "Clever" Dockerfiles
+
+I recently reviewed a project where the team was extremely proud of their "optimized" Dockerfile. It used a custom Alpine Linux base, manually compiled dependencies from source, and had a complex entrypoint script written in bash.
+
+They thought they were being smart. They were actually building a trap.
+
+Every time a developer changed a single line of CSS, the entire image rebuilt from scratch. The entrypoint script occasionally failed silently, leaving containers running but unresponsive. The custom Alpine image lacked critical debugging tools like `curl`, making production incidents a nightmare to troubleshoot.
+
+The "clever" solution created three new problems for every one it solved.
+
+### The True Cost of Complexity
+
+1. **Slow Feedback Loops:** If your build takes 10 minutes, developers will context-switch. You lose hours of productivity every week.
+2. **Security Risks:** More tools installed means a larger attack surface. Do you really need `wget` and `git` in your production image?
+3. **Fragility:** Complex shell commands inside Dockerfiles are hard to test and prone to breaking when underlying OS packages change.
+
+---
+
+## The Solution: Ruthless Simplicity
+
+Stop trying to outsmart Docker. Use its built-in features the way they were intended.
+
+### 1. Multi-Stage Builds Are Mandatory
+
+I prefer official Debian-based images (like `node:20-slim` or `python:3.12-slim`) over Alpine for most web applications. Alpine uses `musl` libc instead of `glibc`, which can cause bizarre compatibility issues with C++ extensions or Python wheels.
+
+But regardless of your base image, you must use multi-stage builds to separate your build environment from your runtime environment.
+
+```dockerfile
+# Stage 1: Build the application
+FROM node:20-slim AS builder
+WORKDIR /app
+
+# Only copy dependency files first to leverage caching
+COPY package.json yarn.lock ./
+# Use yarn for deterministic installs (or npm ci)
+RUN yarn install --frozen-lockfile
+
+# Now copy the rest of the code
+COPY . .
+# Build the application artifacts
+RUN yarn build
+
+# Stage 2: Create the production image
+FROM node:20-slim AS runner
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Copy only the necessary files from the builder stage
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+
+# Run the app as a non-root user for security
+USER node
+
+# Expose the port
+EXPOSE 3000
+
+# Simple, direct command
+CMD ["node", "dist/index.js"]
+```
+
+### 2. Order Matters: Cache Invalidation
+
+Docker builds images layer by layer. If a layer changes, all subsequent layers are rebuilt.
+
+Look at the `COPY package.json` step in the code above. By copying *only* the dependency files and running `yarn install` *before* copying the rest of the source code, we ensure that dependencies are only re-downloaded when `package.json` actually changes.
+
+If you put `COPY . .` before `yarn install`, any change to a markdown file or a typo fix in a comment will invalidate the cache and force a complete reinstall of all your node modules. That is a massive waste of time.
+
+### 3. Keep the Entrypoint Simple
+
+Don't write complex bash scripts to handle database migrations or environment variable validation inside your container's entrypoint.
+
+Your container should do one thing: run the application.
+
+If you need to run migrations, run them as a separate step in your CI/CD pipeline or as an init container in Kubernetes. If you need to validate environment variables, do it in your application code on startup (e.g., using Zod in TypeScript) so it fails fast and loudly.
+
+---
+
+## The "So What?" Check
+
+Why does any of this matter?
+
+Because CI minutes cost money. Because developers hate waiting. Because shipping a 100MB image across a network is fundamentally faster and less prone to timeout errors than shipping a 1.5GB image.
+
+When you simplify your Dockerfiles, you aren't just saving disk space. You are improving the developer experience, reducing your security footprint, and making your deployment pipeline more resilient.
+
+**Build simple. Fail fast. Scale efficiently.**
+
+Stop over-engineering. Start shipping.


### PR DESCRIPTION
Drafted a new blog post "Why You Should Stop Over-Engineering Your Docker Images" following the specific "Mangesh" persona and technical constraints. The post addresses complex Dockerfiles, multi-stage builds, cache layers, and simple entrypoints.

---
*PR created automatically by Jules for task [5400043583845834653](https://jules.google.com/task/5400043583845834653) started by @1Mangesh1*